### PR TITLE
Cache cursor trial number instead of trial id set

### DIFF
--- a/optuna/samplers/_search_space.py
+++ b/optuna/samplers/_search_space.py
@@ -19,7 +19,7 @@ class IntersectionSearchSpace(object):
     """
 
     def __init__(self) -> None:
-        self._cursor = -1
+        self._cursor = -1  # type: int
         self._search_space = None  # type: Optional[Dict[str, BaseDistribution]]
         self._study_id = None  # type: Optional[int]
 

--- a/optuna/samplers/_search_space.py
+++ b/optuna/samplers/_search_space.py
@@ -54,7 +54,7 @@ class IntersectionSearchSpace(object):
             if self._cursor > trial.number:
                 break
 
-            if trial.state == optuna.trial.TrialState.RUNNING:
+            if not trial.state.is_finished():
                 next_cursor = trial.number
 
             if trial.state != optuna.trial.TrialState.COMPLETE:

--- a/optuna/samplers/_search_space.py
+++ b/optuna/samplers/_search_space.py
@@ -2,7 +2,6 @@ from collections import OrderedDict
 import copy
 from typing import Dict
 from typing import Optional
-from typing import Set
 
 import optuna
 from optuna.distributions import BaseDistribution
@@ -20,7 +19,7 @@ class IntersectionSearchSpace(object):
     """
 
     def __init__(self) -> None:
-        self._known_trials = set()  # type: Set[int]
+        self._cursor = -1
         self._search_space = None  # type: Optional[Dict[str, BaseDistribution]]
         self._study_id = None  # type: Optional[int]
 
@@ -50,14 +49,16 @@ class IntersectionSearchSpace(object):
             if self._study_id != study._study_id:
                 raise ValueError("`IntersectionSearchSpace` cannot handle multiple studies.")
 
-        for trial in study.get_trials(deepcopy=False):
+        next_cursor = self._cursor
+        for trial in reversed(study.get_trials(deepcopy=False)):
+            if self._cursor > trial.number:
+                break
+
+            if trial.state == optuna.trial.TrialState.RUNNING:
+                next_cursor = trial.number
+
             if trial.state != optuna.trial.TrialState.COMPLETE:
                 continue
-
-            if trial.number in self._known_trials:
-                continue
-
-            self._known_trials.add(trial.number)
 
             if self._search_space is None:
                 self._search_space = copy.copy(trial.distributions)
@@ -73,6 +74,7 @@ class IntersectionSearchSpace(object):
             for param_name in delete_list:
                 del self._search_space[param_name]
 
+        self._cursor = next_cursor
         search_space = self._search_space or {}
 
         if ordered_dict:


### PR DESCRIPTION
code review for https://github.com/optuna/optuna/pull/1142

**Before**: 168b550

```
(venv) $ time -p python3 examples/bench.py --params 10 --trials 10000
{'0': 1.9999999999999836, '1': 2.0000000000000067, '2': 1.9999999999999987, '3': 1.9999999999999953, '4': 1.9999999999999876, '5': 2.000000000000002, '6': 2.0000000000000187, '7': 1.999999999999978, '8': 1.9999999999999782, '9': 2.000000000000027}
real 93.48
user 254.24
sys 23.65
```

**After**: abbee966

```
(venv) $ time -p python3 examples/bench.py --params 10 --trials 10000
{'0': 1.9999999999999836, '1': 2.0000000000000067, '2': 1.9999999999999987, '3': 1.9999999999999953, '4': 1.9999999999999876, '5': 2.000000000000002, '6': 2.0000000000000187, '7': 1.999999999999978, '8': 1.9999999999999782, '9': 2.000000000000027}
real 71.15
user 193.49
sys 17.72
```